### PR TITLE
Add types feature flag hint to CSV load error

### DIFF
--- a/crates/polars-io/src/csv/buffer.rs
+++ b/crates/polars-io/src/csv/buffer.rs
@@ -523,7 +523,7 @@ pub(crate) fn init_buffers(
                 )),
                 // TODO (ENUM) support writing to Enum
                 dt => polars_bail!(
-                    ComputeError: "unsupported data type when reading CSV: {} when reading CSV", dt,
+                    ComputeError: "unsupported data type when reading CSV: {}. Note that the types i8, u8, i16, u16, date, datetime, and categorical are behind feature flags.", dt,
                 ),
             };
             Ok(builder)


### PR DESCRIPTION
It took some digging to discover why my `CsvReader::from_path()` call was failing. After looking at the code, I realized I had a schema with `Int16` but that this required the `dtype-i16` feature. Since this error comes at exactly the point a coder would need this info, I thought it would be helpful to list the types which are behind the flag in the likely event that one of them is the issue.